### PR TITLE
Update ci-tests.yml

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -29,6 +29,8 @@ jobs:
 
       # Run manage_Externals
       - name: checkout CESM
+        env:
+          GIT_CLONE_PROTECTION_ACTIVE: false
         run: |
           ./manage_externals/checkout_externals -o
 


### PR DESCRIPTION
Set GIT_CLONE_PROTECTION_ACTIVE to prevent clone failure due to CLM LFS usage.